### PR TITLE
Use compression by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Some of the connector args have default values which override the defaults in th
 - `buffered`: True
 - `get_warnings`: True
 - `raise_on_warnings`: False
-- `use_pure`: True
+- `use_pure`: False
+- `compress`: True
 
 You can override these yourself if you prefer.
 

--- a/dbconnector/dbconnector.py
+++ b/dbconnector/dbconnector.py
@@ -174,7 +174,8 @@ class DBConnector:
             "buffered": True,
             "get_warnings": True,
             "raise_on_warnings": False,
-            "use_pure": True,
+            "use_pure": False,
+            "compress": True
         }
         self.connector_args.update(connector_args)
         self.pool = DBConnectionPool(self.connector_args, pool_size)


### PR DESCRIPTION
Add default value for `compress` and set to True.

Update default value of `use_pure` to False

Fixes #4 